### PR TITLE
very low values are not allowed

### DIFF
--- a/src/ArcPay.sol
+++ b/src/ArcPay.sol
@@ -90,11 +90,13 @@ contract ArcPay is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable {
     }
 
     function mint(address receiver) external payable returns (uint) {
-        require(msg.value > 0, ERROR_MINT_EMPTY);
-        mintHashChain = PoseidonT5.hash([uint(uint160(receiver)), maxCoin, maxCoin+msg.value-1, mintHashChain]);
+        // the caller should only send huge values in terms of Wei.
+        uint msgValue = msg.value / uint(10**11);
+        require(msgValue > 0, ERROR_MINT_EMPTY);
+        mintHashChain = PoseidonT5.hash([uint(uint160(receiver)), maxCoin, maxCoin+msgValue-1, mintHashChain]);
         mints[mintHashChain] = block.timestamp;
-        emit Mint(receiver, maxCoin, maxCoin+msg.value, block.timestamp);
-        maxCoin += msg.value;
+        emit Mint(receiver, maxCoin, maxCoin+msgValue, block.timestamp);
+        maxCoin += msgValue;
         return mintHashChain;
     }
 
@@ -175,4 +177,3 @@ contract ArcPay is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable {
     // any eth sent is part of the slashable stake
     receive() external payable {}
 }
-

--- a/test/ArcPay.t.sol
+++ b/test/ArcPay.t.sol
@@ -112,12 +112,12 @@ contract ArcPayTest is Test {
         arcV2 = ArcPayV2(payable(address(arcProxy)));
         assertTrue(arcV2.v2());
 
-        arcV2.mint{value: 1}(address(this));
+        arcV2.mint{value: 1 ether}(address(this));
 
         assertEq(arcV2.operator(), operator);
     }
 
     function testMint() public {
-        arc.mint{value: 1}(address(1));
+        arc.mint{value: 1 ether}(address(1));
     }
 }


### PR DESCRIPTION
very low values are not useful to send. These low values increases the merkle tree size since now we have a wider range for coin IDs.

We store msg.value/1e11 for coin IDs.